### PR TITLE
remove debug output and fix exit code

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -103,7 +103,6 @@ const getStationId = async stations => {
 
     taskler(tasks, () => {
       console.info(green('🎉  Done'));
-      process.exit(0);
     });
   } catch (err) {
     console.error(err);

--- a/cli.js
+++ b/cli.js
@@ -54,8 +54,6 @@ const getStationId = async stations => {
 
     const stationId = await getStationId(chooseBetweenAvailableStations);
 
-    console.log(stationsCollection, stationId);
-
     const {name, stationsPath} = stationsCollection.find(({value}) => value === stationId);
 
     const station = await loadStationByName({name, stationsPath});
@@ -105,8 +103,10 @@ const getStationId = async stations => {
 
     taskler(tasks, () => {
       console.info(green('🎉  Done'));
+      process.exit(0);
     });
   } catch (err) {
     console.error(err);
+    process.exit(1);
   }
 })();

--- a/cli.js
+++ b/cli.js
@@ -88,7 +88,7 @@ const getStationId = async stations => {
     }
 
     tasks.push({
-      title: `Create files for station ${name}`,
+      title: `Created files for station ${name}`,
       task: ({emit, succeed}) => {
         createFilesByList(files, emit).then(succeed);
       }


### PR DESCRIPTION
node without a proper process.exit will exit with a non-zero exit code, resulting in npm reporting an error even though everything went fine